### PR TITLE
Fix guide link in READEME.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ horizontal-rule | drawHorizontalRule | Insert Horizontal Line<br>fa fa-minus
 preview | togglePreview | Toggle Preview<br>fa fa-eye no-disable
 side-by-side | toggleSideBySide | Toggle Side by Side<br>fa fa-columns no-disable no-mobile
 fullscreen | toggleFullScreen | Toggle Fullscreen<br>fa fa-arrows-alt no-disable no-mobile
-guide | [This link](https://inscrybmde.com/markdown-guide) | Markdown Guide<br>fa fa-question-circle
+guide | [This link](https://www.inscryb.com/InscrybMDE/markdown-guide) | Markdown Guide<br>fa fa-question-circle
 
 Customize the toolbar using the `toolbar` option like:
 


### PR DESCRIPTION
Noticed the guide link was broken in the README.md so matched it to the link used in the code.